### PR TITLE
Support for a default route handler

### DIFF
--- a/examples/test.html
+++ b/examples/test.html
@@ -17,6 +17,11 @@
                     console.log("localpage2: "+type);
                     console.log(match);
                 }
+            }, { 
+                defaultHandler: function(type, ui, page) {
+                    console.log("Default handler called due to unknown route (" + type + ", " + ui + ", " + page + ")");
+                },
+                defaultHandlerEvents: "s"
             });
             setTimeout(function(){
                 alert("adding a dynamic route to localpage3...");

--- a/examples/testAjax.html
+++ b/examples/testAjax.html
@@ -23,7 +23,12 @@
               console.log("ajaxPage: "+type);
               console.log(match);
             }
-          });
+          }, { 
+            defaultHandler: function(type, ui, page) {
+                console.log("Default handler called due to unknown route (" + type + ", " + ui + ", " + page + ")");
+            },
+            defaultHandlerEvents: "s"
+        });
           setTimeout(function(){
             alert("deactivating router...");
             router.destroy();

--- a/examples/testArraySyntax.html
+++ b/examples/testArraySyntax.html
@@ -31,7 +31,12 @@
 			console.log("localpage function C: "+type);
 			console.log(params);
                 }
-	});
+	},{ 
+        defaultHandler: function(type, ui, page) {
+            console.log("Default handler called due to unknown route (" + type + ", " + ui + ", " + page + ")");
+        },
+        defaultHandlerEvents: "s"
+    });
         setTimeout(function(){
         	alert("adding a dynamic route to localpage3...");
 		router.add([

--- a/examples/testSamePage.html
+++ b/examples/testSamePage.html
@@ -14,6 +14,11 @@
                     console.log("localpage2: "+type);
                     console.log(match);
                 }
+            }, { 
+                defaultHandler: function(type, ui, page) {
+                    console.log("Default handler called due to unknown route (" + type + ", " + ui + ", " + page + ")");
+                },
+                defaultHandlerEvents: "s"
             });
         </script>
 </head>


### PR DESCRIPTION
I've added support for a default handler that is invoked in cases the url does not satsify any of the routes that have been set up

Also there was a bug with the config parameter not being applied when you call new $.mobile.Router(), which has been fixed.
