### PR TITLE
Adds better stack trace to error messages

### DIFF
--- a/js/jquery.mobile.router.js
+++ b/js/jquery.mobile.router.js
@@ -38,7 +38,10 @@ $(document).bind("mobileinit",function(){
 
 	var DEBUG=true;
 	function debug(err){
-		if (DEBUG) console.log(err);
+          if (DEBUG) {
+            console.log(err);
+            if (err.stack) console.log(err.stack)
+          }
 	}
 
 	var previousUrl=null, nextUrl=null, ignoreNext=false;


### PR DESCRIPTION
Found that in Chrome when an error happens in say a handler function the
try/catch block would catch the error and pass it along to the debug()
method. The problem is that when the debug function in turn does a
console.log(err) it looses the stack trace and your not able to see what
happened.

This might be the limitations of Chrome's console but adding the
err.stack allows the developer a peek into the cause of any errors
thrown.
