### PR TITLE
Fixing issue #73: debugging snippet gets in the way

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,12 +449,16 @@ jQuery Mobile Router supports the following parameters:
 		route is found. You MUST also define the `defaultHandlerEvents` property when using
     this one
 
+*`debugHandler`: a function reference or a function name that will be called with
+    debugging information. If none supplied, this will default to ``console.log`` if
+    such exists. Set this to `null` to disable debugging completely.
+
 *`defaultHandlerEvents`: the defaultHandler will be called for these events, if
 		no routes are matched. Please note that THESE EVENTS MUST BE DEFINED 
 		AT LEAST ONCE IN ANOTHER ROUTE, otherwise the defaultHandler won't be executed.
 		That is to say, if your routes are defined for "pagebeforeshow" and "pageshow"
 		events only, a defaultHandler for the "pagehide" event won't work!
-
+		
 
 You can pass an object with the above properties to the single router instance or set it
 globally with this code (must be used BEFORE loading jquery.mobile.router.js):

--- a/js/jquery.mobile.router.js
+++ b/js/jquery.mobile.router.js
@@ -29,16 +29,25 @@ $(document).on("mobileinit", function(){
   */
 
   var config = $.extend({
-    fixFirstPageDataUrl: false, firstPageDataUrl: "index.html",
-    ajaxApp: false, firstMatchOnly: false
+    fixFirstPageDataUrl: false,
+    firstPageDataUrl: "index.html",
+    ajaxApp: false,
+    firstMatchOnly: false
   }, $.mobile.jqmRouter || {});
 
-
-  var DEBUG = true;
-  function debug(err){
-    if (DEBUG) {
-      console.log(err);
-      if (err.stack){ console.log(err.stack); }
+  var debug;
+  if (config.debugHandler === null){
+      // Debugging disabled
+      debug = function(){};
+  } else {
+    if (config.debugHandler){
+        debug = config.debugHandler;
+    } else {
+      if(console.log){
+        debug = function(){
+          console.log.apply(console, arguments);
+        };
+      }
     }
   }
 

--- a/js/jquery.mobile.router.js
+++ b/js/jquery.mobile.router.js
@@ -132,6 +132,7 @@ $(document).on("mobileinit", function(){
     debug: function(){
       var conf = this.conf;
       
+      // debugHandler === null means disable debug entirely
       if (conf.debugHandler !== null){
         if (conf.debugHandler){
           conf.debugHandler.apply(null, arguments);

--- a/js/jquery.mobile.router.js
+++ b/js/jquery.mobile.router.js
@@ -35,22 +35,6 @@ $(document).on("mobileinit", function(){
     firstMatchOnly: false
   }, $.mobile.jqmRouter || {});
 
-  var debug;
-  if (config.debugHandler === null){
-      // Debugging disabled
-      debug = function(){};
-  } else {
-    if (config.debugHandler){
-        debug = config.debugHandler;
-    } else {
-      if(console.log){
-        debug = function(){
-          console.log.apply(console, arguments);
-        };
-      }
-    }
-  }
-
   var previousUrl = null, nextUrl = null, ignoreNext = false;
 
   $(document).on("pagebeforechange", function(e, data) {
@@ -142,8 +126,23 @@ $(document).on("mobileinit", function(){
       }
     }
     this.add(userRoutes,userHandlers);
-  }
+  };
+  
   $.extend($.mobile.Router.prototype,{
+    debug: function(){
+      var conf = this.conf;
+      
+      if (conf.debugHandler !== null){
+        if (conf.debugHandler){
+          conf.debugHandler.apply(null, arguments);
+        } else {
+          if(console.log){
+            console.log.apply(console, arguments);
+          }
+        }
+      }
+    },
+    
     documentEvts: { pagebeforechange:1, pagebeforeload:1, pageload:1 },
 
     add: function(userRoutes,userHandlers,_skipAttach){
@@ -177,7 +176,7 @@ $(document).on("mobileinit", function(){
                   _self.routesRex[r] = new RegExp(r);
                 }
               } else {
-                debug("can't set unsupported route " + trig[i]);
+                _self.debug("can't set unsupported route " + trig[i]);
               }
             }
           }
@@ -269,12 +268,14 @@ $(document).on("mobileinit", function(){
           }
           if ( handleFn ){
             try {
-	      if (bCDeferred && ui){
+              if (bCDeferred && ui){
                 ui.bCDeferred = bCDeferred;
-	      }
+	          }
               handleFn.apply(_self.userHandlers, [e.type,res,ui,page,e]);
               bHandled = true;
-            }catch(err){ debug(err); }
+            }catch(err){
+              _self.debug(err);
+            }
           }
         }
         if ( bHandled && _self.conf.firstMatchOnly ) return false;
@@ -283,13 +284,13 @@ $(document).on("mobileinit", function(){
       if ( !bHandled && this.conf.defaultHandler && this.defaultHandlerEvents[e.type] ) {
         var handleFn;
         if ( typeof(this.conf.defaultHandler) == "function" ) {
-	  handleFn = this.conf.defaultHandler;
+          handleFn = this.conf.defaultHandler;
         } else if ( typeof(this.userHandlers[this.conf.defaultHandler]) == "function" ) {
           handleFn = this.userHandlers[this.conf.defaultHandler];
         }
-	try {
-	  handleFn.apply(this.userHandlers, [e.type, ui, page, e]);
-	} catch(err){ debug(err); }
+        try {
+          handleFn.apply(this.userHandlers, [e.type, ui, page, e]);
+        } catch(err){ _self.debug(err); }
       }
 
       if (e.type=="pagebeforechange" && bHandled){


### PR DESCRIPTION
Two notes:
- I am just starting to test this now, so this pull request is sent in order to get a code review.
- I have added the option to specify `debugHandler: null` in order to disable debugging entirely. It is an odd way of doing so, but will preserve backwards compatibility.
