### PR TITLE
Add reverse option (as in "reverse" transition) to bC deferred callback

### DIFF
--- a/js/jquery.mobile.router.js
+++ b/js/jquery.mobile.router.js
@@ -314,7 +314,7 @@ $(document).on("mobileinit", function(){
 	  // I'm using ui.toPage so that really crazy users may try to re-route the transition to
 	  //   another location by modifying this property from the handler.
 	  $.mobile.changePage(ui.toPage, $.extend({
-            dataUrl: ui.options.dataUrl
+            dataUrl: ui.options.dataUrl, reverse: ui.options.reverse
           }, extraOpt ));
 	});
       }


### PR DESCRIPTION
With version v20130525 one is supposed to call ui.bCDeferred.resolve() inside the bC event in order to resume normal flow. However, data-direction=reverse (or reverse=true) behaviour is lost for all pages going through the bC event handler and getting rescued with resolve().

**Solution**: added ui.options.reverse in the deferred done callback. Actually shouldn't all ui.options parameters be extended within the same call?

``` javascript
// my solution
$.mobile.changePage(ui.toPage, $.extend({
            dataUrl: ui.options.dataUrl, reverse: ui.options.reverse
          }, extraOpt ));

// better?
$.mobile.changePage(ui.toPage, $.extend({
            ui.options
          }, extraOpt ));
```
